### PR TITLE
[codex] Add portfolio v2 preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Include your project-specific ignores in this file
 # Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
 /node_modules/
+.DS_Store
+/mockups/

--- a/v2/index.html
+++ b/v2/index.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Dharmendra Vishwakarma | AI Platform Engineering Leader</title>
+    <meta
+      name="description"
+      content="Dharmendra Vishwakarma is a senior engineering leader building secure AI platforms, document automation systems, and cloud-native enterprise software."
+    >
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="theme-color" content="#f7f4ec">
+
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="Dharmendra Vishwakarma | AI Platform Engineering Leader">
+    <meta
+      property="og:description"
+      content="Secure AI platforms, document intelligence, cloud-native enterprise systems, and engineering leadership."
+    >
+    <meta property="og:url" content="https://www.vdharam.com/v2/">
+    <meta property="og:image" content="https://www.vdharam.com/images/Dharmendra_Vishwakarma_Professional_Pic.jpeg">
+
+    <link rel="icon" href="../favicon.ico">
+    <link rel="apple-touch-icon" href="../apple-touch-icon.png">
+    <link rel="canonical" href="https://www.vdharam.com/v2/">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&display=swap"
+      rel="stylesheet"
+    >
+    <link rel="stylesheet" href="./styles.css">
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Dharmendra Vishwakarma",
+        "alternateName": "Dharam",
+        "url": "https://www.vdharam.com/",
+        "image": "https://www.vdharam.com/images/Dharmendra_Vishwakarma_Professional_Pic.jpeg",
+        "jobTitle": "Senior Engineer",
+        "worksFor": {
+          "@type": "Organization",
+          "name": "DocuSign"
+        },
+        "alumniOf": {
+          "@type": "CollegeOrUniversity",
+          "name": "National College of Ireland"
+        },
+        "sameAs": [
+          "https://www.linkedin.com/in/vdharam/",
+          "https://github.com/dharm18",
+          "https://vdharam.wordpress.com"
+        ],
+        "knowsAbout": [
+          "AI platform engineering",
+          "secure document processing",
+          "cloud-native microservices",
+          "Java",
+          "Spring Boot",
+          "enterprise software architecture"
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header" aria-label="Primary navigation">
+      <a class="brand" href="#top" aria-label="Dharmendra Vishwakarma home">
+        <span class="brand-mark">DV</span>
+        <span class="brand-copy">
+          <strong>Dharmendra Vishwakarma</strong>
+          <span>AI Platform Engineering</span>
+        </span>
+      </a>
+
+      <nav class="nav-links" aria-label="Main">
+        <a href="#impact">Impact</a>
+        <a href="#case-studies">Case Studies</a>
+        <a href="#operating-model">Operating Model</a>
+        <a href="#writing">Writing</a>
+      </nav>
+
+      <a class="nav-cta" href="#contact">Contact</a>
+    </header>
+
+    <main id="main">
+      <section id="top" class="hero" aria-labelledby="hero-title">
+        <div class="hero-copy">
+          <p class="eyebrow">Senior Engineer | DocuSign AI | Dublin</p>
+          <h1 id="hero-title">Secure AI platforms for enterprise document intelligence.</h1>
+          <p class="hero-lede">
+            I help teams turn complex enterprise workflows into reliable, cloud-native products,
+            with a focus on AI platform foundations, secure document processing, and calm technical leadership.
+          </p>
+
+          <div class="hero-actions" aria-label="Primary actions">
+            <a class="button button-primary" href="#case-studies">Explore selected work</a>
+            <a class="button button-secondary" href="https://drive.google.com/file/d/1ChadjBaEb2HN5NwbH6QTNJ8xD1TWAPot/view?usp=sharing" target="_blank" rel="noopener">
+              Resume
+            </a>
+          </div>
+
+          <div class="trust-row" aria-label="Career highlights">
+            <span>DocuSign AI</span>
+            <span>Mastercard</span>
+            <span>Java and Spring</span>
+            <span>Cloud-native platforms</span>
+          </div>
+        </div>
+
+        <aside class="hero-panel" aria-label="Profile summary">
+          <figure class="portrait">
+            <img
+              src="../images/Dharmendra_Vishwakarma_Professional_Pic.jpeg"
+              alt="Dharmendra Vishwakarma"
+              width="420"
+              height="420"
+            >
+          </figure>
+          <div class="profile-card">
+            <p class="panel-label">Current signal</p>
+            <h2>Engineering leader for trusted AI product foundations.</h2>
+            <dl>
+              <div>
+                <dt>12+</dt>
+                <dd>years in enterprise software</dd>
+              </div>
+              <div>
+                <dt>AI</dt>
+                <dd>document intelligence platforms</dd>
+              </div>
+              <div>
+                <dt>Lead</dt>
+                <dd>architecture, delivery, mentoring</dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
+      </section>
+
+      <section id="impact" class="section impact-section" aria-labelledby="impact-title">
+        <div class="section-kicker">Career Impact</div>
+        <div class="split-heading">
+          <h2 id="impact-title">A career story built around reliable systems and useful AI.</h2>
+          <p>
+            This v2 direction emphasizes future-facing strengths: platform engineering, secure workflows,
+            technical leadership, and the ability to connect architecture with delivery.
+          </p>
+        </div>
+
+        <div class="impact-grid">
+          <article>
+            <span>01</span>
+            <h3>DocuSign AI platform engineering</h3>
+            <p>
+              Lead engineering initiatives in AI-backed document systems, where security, scale,
+              reliability, and product judgment need to work together.
+            </p>
+          </article>
+          <article>
+            <span>02</span>
+            <h3>Enterprise cloud-native delivery</h3>
+            <p>
+              Build and evolve Java, Spring Boot, API, and microservice systems for high-stakes
+              enterprise environments including payments and document automation.
+            </p>
+          </article>
+          <article>
+            <span>03</span>
+            <h3>Data and ML foundation</h3>
+            <p>
+              Bring data analytics training and machine learning project experience into practical,
+              production-aware engineering decisions.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="case-studies" class="section case-section" aria-labelledby="case-title">
+        <div class="section-kicker">Selected Work</div>
+        <div class="split-heading">
+          <h2 id="case-title">Case studies with problem, architecture, tradeoffs, and outcome.</h2>
+          <p>
+            The current portfolio has good raw material. V2 reframes it into focused stories that
+            recruiters can scan and engineering leaders can inspect.
+          </p>
+        </div>
+
+        <div class="case-grid">
+          <article class="case-card case-featured">
+            <div class="case-topline">
+              <span>Platform</span>
+              <span>DocuSign AI</span>
+            </div>
+            <h3>Secure document intelligence services</h3>
+            <p>
+              A flagship case study for AI platform work: service boundaries, reliability concerns,
+              privacy-aware workflows, evaluation loops, and delivery leadership.
+            </p>
+            <ul>
+              <li>Architecture and integration patterns</li>
+              <li>Risk controls and operational quality</li>
+              <li>Team execution and decision framing</li>
+            </ul>
+          </article>
+
+          <article class="case-card">
+            <div class="case-topline">
+              <span>Fintech</span>
+              <span>Mastercard</span>
+            </div>
+            <h3>Cloud-native payment services</h3>
+            <p>
+              Proof of enterprise-grade engineering: APIs, microservices, domain complexity,
+              release discipline, and production behavior.
+            </p>
+          </article>
+
+          <article class="case-card">
+            <div class="case-topline">
+              <span>Security ML</span>
+              <span>Research</span>
+            </div>
+            <h3>Malicious web page detection</h3>
+            <p>
+              A modern AI and security story with feature design, model comparison,
+              evaluation metrics, and lessons learned.
+            </p>
+          </article>
+
+          <article class="case-card">
+            <div class="case-topline">
+              <span>Data</span>
+              <span>Analytics</span>
+            </div>
+            <h3>Big data and decision systems</h3>
+            <p>
+              Curated academic work as concise examples of data pipelines, storage choices,
+              dashboards, and practical analysis.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="operating-model" class="section model-section" aria-labelledby="model-title">
+        <div class="model-copy">
+          <p class="section-kicker">Operating Model</p>
+          <h2 id="model-title">How I move from ambiguity to production.</h2>
+          <p>
+            This section becomes a signature differentiator. It explains engineering judgment:
+            how risk is evaluated, boundaries are clarified, technology is chosen, and teams keep moving.
+          </p>
+        </div>
+
+        <div class="system-board" aria-label="Engineering operating model">
+          <article>
+            <span>Frame</span>
+            <h3>Define the business risk and user promise.</h3>
+          </article>
+          <article>
+            <span>Design</span>
+            <h3>Set service boundaries, contracts, and data flow.</h3>
+          </article>
+          <article>
+            <span>Build</span>
+            <h3>Ship incrementally with production feedback loops.</h3>
+          </article>
+          <article>
+            <span>Lead</span>
+            <h3>Make tradeoffs visible and help people do their best work.</h3>
+          </article>
+        </div>
+      </section>
+
+      <section id="writing" class="section writing-section" aria-labelledby="writing-title">
+        <div class="section-kicker">Writing Engine</div>
+        <div class="split-heading">
+          <h2 id="writing-title">A living body of work for future growth.</h2>
+          <p>
+            Short technical essays can make the site compound over time. These topics align
+            with AI platforms, secure systems, and engineering leadership.
+          </p>
+        </div>
+
+        <div class="writing-list">
+          <article>
+            <span>AI Platforms</span>
+            <h3>Designing service boundaries for document intelligence systems</h3>
+          </article>
+          <article>
+            <span>Security</span>
+            <h3>What enterprise AI teams should measure before scaling</h3>
+          </article>
+          <article>
+            <span>Leadership</span>
+            <h3>How calm delivery works when the system is complex</h3>
+          </article>
+        </div>
+      </section>
+
+      <section class="section proof-section" aria-labelledby="proof-title">
+        <div>
+          <p class="section-kicker">Proof</p>
+          <h2 id="proof-title">Trust signals without clutter.</h2>
+        </div>
+        <div class="proof-list">
+          <p>
+            <strong>Recommendations:</strong> peer testimonials become short, attributed proof blocks.
+          </p>
+          <p>
+            <strong>Resume:</strong> create an on-site resume, with downloadable PDF as the secondary path.
+          </p>
+          <p>
+            <strong>Certifications:</strong> curate relevant certificates instead of listing everything.
+          </p>
+          <p>
+            <strong>GitHub:</strong> highlight selected repositories and contributions by theme.
+          </p>
+        </div>
+      </section>
+
+      <section id="contact" class="contact-band" aria-labelledby="contact-title">
+        <div>
+          <p class="section-kicker">Next Step</p>
+          <h2 id="contact-title">Turn this into the new vdharam.com.</h2>
+          <p>
+            After reviewing V2, we can promote this direction into the root homepage and then
+            evolve it into a structured content system for case studies, writing, resume data, and SEO.
+          </p>
+        </div>
+        <div class="contact-actions">
+          <a class="button button-primary" href="https://www.linkedin.com/in/vdharam/" target="_blank" rel="noopener">LinkedIn</a>
+          <a class="button button-secondary" href="https://github.com/dharm18" target="_blank" rel="noopener">GitHub</a>
+          <a class="button button-tertiary" href="../">Legacy site</a>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/v2/styles.css
+++ b/v2/styles.css
@@ -1,0 +1,664 @@
+:root {
+  color-scheme: light;
+  --ink: #111416;
+  --ink-soft: #2d3438;
+  --muted: #5a6469;
+  --paper: #f7f4ec;
+  --surface: #fffdf7;
+  --surface-cool: #edf6f4;
+  --line: #d8d0c2;
+  --teal: #006b5c;
+  --blue: #1f5f8b;
+  --rust: #a9442d;
+  --gold: #91680d;
+  --forest: #173d36;
+  --shadow: 0 24px 64px rgba(17, 20, 22, 0.12);
+  --measure: 68ch;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background:
+    linear-gradient(90deg, rgba(17, 20, 22, 0.035) 1px, transparent 1px),
+    linear-gradient(rgba(17, 20, 22, 0.035) 1px, transparent 1px),
+    var(--paper);
+  background-size: 44px 44px;
+  color: var(--ink);
+  font-family: "Atkinson Hyperlegible", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 17px;
+  line-height: 1.58;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: inherit;
+  text-underline-offset: 0.2em;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -5rem;
+  z-index: 20;
+  padding: 0.7rem 1rem;
+  background: var(--ink);
+  color: var(--surface);
+}
+
+.skip-link:focus {
+  top: 1rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto minmax(90px, 1fr);
+  align-items: center;
+  gap: 1rem;
+  min-height: 74px;
+  padding: 0.8rem clamp(1rem, 4vw, 3.5rem);
+  border-bottom: 1px solid var(--line);
+  background: rgba(247, 244, 236, 0.92);
+  backdrop-filter: blur(18px);
+}
+
+.brand,
+.nav-links a,
+.nav-cta,
+.button {
+  text-decoration: none;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: fit-content;
+  min-width: 0;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  background: var(--ink);
+  color: var(--surface);
+  font-weight: 700;
+}
+
+.brand-copy {
+  display: grid;
+  line-height: 1.12;
+}
+
+.brand-copy strong {
+  font-size: 0.96rem;
+}
+
+.brand-copy span {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.8rem, 2vw, 1.5rem);
+  color: var(--ink-soft);
+  font-size: 0.94rem;
+}
+
+.nav-links a:hover {
+  color: var(--teal);
+}
+
+.nav-cta {
+  justify-self: end;
+  min-width: 90px;
+  padding: 0.68rem 0.95rem;
+  border: 1px solid var(--ink);
+  border-radius: 8px;
+  background: var(--ink);
+  color: var(--surface);
+  font-weight: 700;
+  text-align: center;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.14fr) minmax(330px, 0.86fr);
+  gap: clamp(2rem, 5vw, 5.5rem);
+  align-items: center;
+  min-height: calc(100vh - 74px);
+  padding: clamp(3rem, 7vw, 6rem) clamp(1rem, 5vw, 5rem) clamp(2.5rem, 6vw, 4rem);
+}
+
+.hero-copy {
+  max-width: 880px;
+}
+
+.eyebrow,
+.section-kicker,
+.panel-label,
+.case-topline,
+.trust-row,
+.system-board span,
+.writing-list span {
+  color: var(--teal);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.eyebrow,
+.section-kicker,
+.panel-label {
+  margin: 0 0 0.85rem;
+}
+
+h1,
+h2,
+h3,
+p,
+figure {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 980px;
+  margin-bottom: 1.1rem;
+  font-size: clamp(3.1rem, 7.2vw, 7.8rem);
+  line-height: 0.92;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: clamp(2.05rem, 4.8vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: 0;
+}
+
+h3 {
+  line-height: 1.08;
+}
+
+.hero-lede {
+  max-width: var(--measure);
+  color: var(--ink-soft);
+  font-size: clamp(1.1rem, 1.55vw, 1.45rem);
+  line-height: 1.48;
+}
+
+.hero-actions,
+.contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.7rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 0.78rem 1.05rem;
+  border: 1px solid var(--ink);
+  border-radius: 8px;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+.button-primary {
+  background: var(--ink);
+  color: var(--surface);
+}
+
+.button-secondary {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.button-tertiary {
+  color: var(--surface);
+  background: transparent;
+  border-color: rgba(255, 253, 247, 0.35);
+}
+
+.trust-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: 2rem;
+  color: var(--blue);
+}
+
+.trust-row span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 253, 247, 0.76);
+}
+
+.hero-panel {
+  display: grid;
+  gap: 1rem;
+  align-self: stretch;
+}
+
+.portrait {
+  position: relative;
+  min-height: 360px;
+  margin-bottom: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-cool);
+  box-shadow: var(--shadow);
+}
+
+.portrait::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 33%;
+  background:
+    linear-gradient(90deg, var(--teal) 0 28%, transparent 28% 34%, var(--rust) 34% 62%, transparent 62% 68%, var(--gold) 68% 100%);
+  opacity: 0.9;
+  clip-path: polygon(0 52%, 100% 20%, 100% 100%, 0 100%);
+}
+
+.portrait img {
+  width: 100%;
+  height: 100%;
+  min-height: 360px;
+  object-fit: cover;
+  object-position: 50% 24%;
+  filter: saturate(0.9) contrast(1.03);
+}
+
+.profile-card {
+  padding: 1.2rem;
+  border-radius: 8px;
+  background: var(--forest);
+  color: var(--surface);
+}
+
+.profile-card h2 {
+  max-width: 18ch;
+  font-size: clamp(1.45rem, 2.5vw, 2.2rem);
+  line-height: 1.06;
+}
+
+.profile-card dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 1.4rem 0 0;
+  background: rgba(255, 253, 247, 0.18);
+  border: 1px solid rgba(255, 253, 247, 0.18);
+}
+
+.profile-card dl div {
+  padding: 0.85rem;
+  background: rgba(255, 253, 247, 0.06);
+}
+
+.profile-card dt {
+  font-size: clamp(1.45rem, 3vw, 2.25rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.profile-card dd {
+  margin: 0.4rem 0 0;
+  color: rgba(255, 253, 247, 0.8);
+  font-size: 0.92rem;
+  line-height: 1.35;
+}
+
+.section {
+  padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 5vw, 5rem);
+}
+
+.split-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1.06fr) minmax(280px, 0.94fr);
+  gap: clamp(1.3rem, 4vw, 5rem);
+  align-items: end;
+  margin-bottom: clamp(1.7rem, 4vw, 3.2rem);
+}
+
+.split-heading p,
+.model-copy p,
+.contact-band p,
+.case-card p,
+.impact-grid p,
+.proof-list p {
+  max-width: var(--measure);
+  color: var(--muted);
+}
+
+.impact-section {
+  background: var(--surface);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.impact-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+
+.impact-grid article {
+  min-height: 300px;
+  padding: clamp(1.15rem, 3vw, 2rem);
+  background: var(--surface);
+}
+
+.impact-grid span {
+  color: var(--rust);
+  font-weight: 700;
+}
+
+.impact-grid h3 {
+  margin: 3rem 0 0.8rem;
+  font-size: clamp(1.35rem, 2vw, 2rem);
+}
+
+.case-section {
+  background: var(--paper);
+}
+
+.case-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.case-card {
+  min-height: 360px;
+  padding: 1.25rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: 0 14px 38px rgba(17, 20, 22, 0.06);
+}
+
+.case-featured {
+  grid-column: span 2;
+  background: var(--surface-cool);
+}
+
+.case-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: var(--blue);
+}
+
+.case-card h3 {
+  margin: 4rem 0 0.9rem;
+  font-size: clamp(1.4rem, 2.6vw, 2.8rem);
+}
+
+.case-card:not(.case-featured) h3 {
+  margin-top: 3rem;
+  font-size: 1.55rem;
+}
+
+.case-card ul {
+  display: grid;
+  gap: 0.45rem;
+  margin: 1.25rem 0 0;
+  padding-left: 1.15rem;
+  color: var(--ink-soft);
+}
+
+.model-section {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.28fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  background: var(--ink);
+  color: var(--surface);
+}
+
+.model-copy {
+  align-self: center;
+}
+
+.model-copy .section-kicker,
+.model-section .system-board span {
+  color: #88d6c9;
+}
+
+.model-copy p {
+  color: rgba(255, 253, 247, 0.75);
+}
+
+.system-board {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  padding: 1px;
+  background:
+    linear-gradient(rgba(255, 253, 247, 0.09) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 253, 247, 0.09) 1px, transparent 1px),
+    rgba(255, 253, 247, 0.2);
+  background-size: 40px 40px;
+  border: 1px solid rgba(255, 253, 247, 0.2);
+}
+
+.system-board article {
+  min-height: 230px;
+  padding: 1.25rem;
+  background: rgba(17, 20, 22, 0.86);
+}
+
+.system-board h3 {
+  margin: 4.8rem 0 0;
+  font-size: clamp(1.35rem, 2.4vw, 2.35rem);
+}
+
+.writing-section {
+  background: var(--surface);
+}
+
+.writing-list {
+  display: grid;
+  gap: 1px;
+  border: 1px solid var(--line);
+  background: var(--line);
+}
+
+.writing-list article {
+  display: grid;
+  grid-template-columns: 170px minmax(0, 1fr);
+  gap: 1rem;
+  align-items: center;
+  padding: 1.15rem;
+  background: var(--surface);
+}
+
+.writing-list h3 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2.8vw, 2.35rem);
+}
+
+.proof-section {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.65fr) minmax(0, 1.35fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  background: var(--paper);
+}
+
+.proof-list {
+  display: grid;
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+}
+
+.proof-list p {
+  margin: 0;
+  padding: 1rem;
+  background: rgba(255, 253, 247, 0.72);
+}
+
+.proof-list strong {
+  color: var(--ink);
+}
+
+.contact-band {
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(260px, 0.82fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  align-items: center;
+  margin: clamp(1rem, 5vw, 5rem);
+  padding: clamp(2rem, 5vw, 4rem);
+  border-radius: 8px;
+  background: var(--forest);
+  color: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.contact-band .section-kicker {
+  color: #f0c862;
+}
+
+.contact-band p {
+  color: rgba(255, 253, 247, 0.75);
+}
+
+.contact-actions {
+  justify-content: flex-end;
+  margin-top: 0;
+}
+
+.contact-actions .button-primary {
+  background: var(--surface);
+  color: var(--ink);
+  border-color: var(--surface);
+}
+
+.contact-actions .button-secondary {
+  color: var(--surface);
+  background: transparent;
+  border-color: rgba(255, 253, 247, 0.35);
+}
+
+@media (max-width: 1120px) {
+  .site-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .nav-links {
+    display: none;
+  }
+
+  .hero,
+  .model-section,
+  .proof-section {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-panel {
+    grid-template-columns: minmax(280px, 0.85fr) minmax(280px, 1fr);
+    align-items: stretch;
+  }
+
+  .portrait,
+  .portrait img {
+    min-height: 320px;
+  }
+
+  .case-grid,
+  .impact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  body {
+    font-size: 16px;
+  }
+
+  .site-header {
+    position: static;
+    min-height: 68px;
+  }
+
+  .brand-copy span {
+    display: none;
+  }
+
+  .nav-cta {
+    padding-inline: 0.8rem;
+  }
+
+  .hero {
+    min-height: auto;
+    padding-top: 3rem;
+  }
+
+  .hero-panel,
+  .split-heading,
+  .case-grid,
+  .impact-grid,
+  .profile-card dl,
+  .system-board,
+  .writing-list article,
+  .contact-band {
+    grid-template-columns: 1fr;
+  }
+
+  .case-featured {
+    grid-column: span 1;
+  }
+
+  .case-card,
+  .impact-grid article,
+  .system-board article {
+    min-height: auto;
+  }
+
+  .case-card h3,
+  .case-card:not(.case-featured) h3,
+  .impact-grid h3,
+  .system-board h3 {
+    margin-top: 2.2rem;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .contact-actions {
+    justify-content: stretch;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new `/v2/` portfolio preview route while leaving the current root `index.html` untouched.
- Introduce a refined AI platform engineering positioning, case-study structure, operating model, writing engine, and proof sections.
- Add preview-safe metadata, Open Graph tags, Person JSON-LD, and WCAG AA-checked color choices.
- Ignore local `.DS_Store` and `mockups/` artifacts.

## Validation
- Loaded `/v2/` from the repo root via local server.
- Confirmed CSS and profile image load.
- Confirmed all sections render and no horizontal overflow in the browser preview.
- Checked main palette contrast pairs against WCAG AA normal-text thresholds.

## Notes
- `/v2/` includes `noindex, nofollow` so it can be reviewed safely before replacing the main homepage.